### PR TITLE
Update config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -50,10 +50,17 @@ $CONFIG = [
 
 /**
  * Define list of trusted domains that users can log into
- * Specifying trusted domains prevents host header poisoning.
+ * Specifying trusted domains prevents host header poisoning. 
+ * This parameter reperesents a white list of approved IP addresses and 
+ * hostnames that this server is known by / is used to access it. Wildcards, 
+ * slash notation and ports are not supported.
  * Do not remove this, as it performs necessary security checks.
  * Please consider that for backend processes like background jobs or occ commands,
  * the URL parameter in key `overwrite.cli.url` is used. For more details, please see that key.
+ *
+ * NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be 
+ * a comma delimited list with no white space. e.g. `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.  
+ * Wildcards, slash notation and ports are not supported.
  */
 'trusted_domains' => [
 	'demo.example.org',


### PR DESCRIPTION
Update core docs to capture updated messaging around OWNCLOUD_TRUSTED_DOMAIN property, esp when used in docker containers.  Re: https://github.com/owncloud/docs-server/pull/1184

This change originates due to user confusion surrounding the correct use and application of the 'OWNCLOUD_TRUSTED_DOMAINS' property. It's not uncommon for current (new) users to expect this value to match trusted client sources and not the names the owncloud server is known by/accessible as.

- [X] Documentation ticket raised: https://github.com/owncloud/core/issues/41086
